### PR TITLE
Update doc tags (used by search engine https://learn.microsoft.com/en-us/samples/browse/)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 ---
 page_type: sample
 languages:
-- cpp
 - csharp
 - python
-name: "Microsoft Azure AI Vision SDK Samples"
-description: ""
+- cpp
+name: "Azure Image Analysis samples"
+description: "C++, C# and Python samples for Image Analysis using Azure AI Vision SDK (Preview)"
 products:
-- azure
 - azure-cognitive-services
 - azure-computer-vision
 ---


### PR DESCRIPTION
Move `C++` to the end of the languages list, since it looks like the search result only shows the first two languages. C++ is probably the least used. This is just a display thing... does not really affect the result. You can limit the search to C++ and it will still show up.

Remove `azure` from the products list. It is not part of a valid value.

Update title and description to be more friendly when you see search results. Emphasize `Image Analysis` since at the moment this is the only think public on the SDK.
