### PR TITLE
Fix missing "using Azure" in the learn.microsoft samples

### DIFF
--- a/docs/learn.microsoft.com/csharp/image-analysis/1/Program.cs
+++ b/docs/learn.microsoft.com/csharp/image-analysis/1/Program.cs
@@ -4,6 +4,7 @@
 //
 
 // <snippet_single>
+using Azure;
 using Azure.AI.Vision.Core.Input;
 using Azure.AI.Vision.Core.Options;
 using Azure.AI.Vision.ImageAnalysis;

--- a/docs/learn.microsoft.com/csharp/image-analysis/2/Program.cs
+++ b/docs/learn.microsoft.com/csharp/image-analysis/2/Program.cs
@@ -4,6 +4,7 @@
 //
 
 // <snippet_single>
+using Azure;
 using Azure.AI.Vision.Core.Input;
 using Azure.AI.Vision.Core.Options;
 using Azure.AI.Vision.ImageAnalysis;

--- a/docs/learn.microsoft.com/csharp/image-analysis/3/Program.cs
+++ b/docs/learn.microsoft.com/csharp/image-analysis/3/Program.cs
@@ -4,6 +4,7 @@
 //
 
 // <snippet_single>
+using Azure;
 using Azure.AI.Vision.Core.Input;
 using Azure.AI.Vision.Core.Options;
 using Azure.AI.Vision.ImageAnalysis;

--- a/samples/csharp/image-analysis/dotnetcore/image-analysis-samples.csproj
+++ b/samples/csharp/image-analysis/dotnetcore/image-analysis-samples.csproj
@@ -15,7 +15,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.Vision.Core" Version="0.10.0-beta.1" />
     <PackageReference Include="Azure.AI.Vision.ImageAnalysis" Version="0.10.0-beta.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Also, there is no need to specify the Azure.AI.Vision.Core package in C# projects, since it gets pulled down automatically. This is not the case for C++ projects for some reason.
