### PR TITLE
Fix Next.js sample WASM crash caused by double SDK initialization

### DIFF
--- a/samples/web/nextjs/face/face.tsx
+++ b/samples/web/nextjs/face/face.tsx
@@ -62,6 +62,7 @@ const FaceLivenessDetectorComponent = ({
   }, [sessionData, loadingToken]);
 
   useEffect(() => {
+    if (!sessionData) return;
     let action = (file !== undefined) ? "detectLivenessWithVerify": "detectLiveness";
     // Step 3: query the azure-ai-vision-face-ui element to process face liveness.
     // For scenarios where you want to use the same element to process multiple sessions, you can query the element once and store it in a variable.


### PR DESCRIPTION
The useEffect that initializes the Face Liveness Detector ran on every sessionData change, including the initial null value. This caused the SDK's WASM module to be loaded twice in parallel, triggering: "Assertion failed: the Module object should not be replaced during async compilation"

Adding a null guard ensures .start() is only called once the session token is available.